### PR TITLE
change crev matrix room reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 * [cargo-crev: Crev for Rust/cargo](https://github.com/crev-dev/cargo-crev) - ready and working
 * [npm-crev: Crev for Node/NPM](https://www.npmjs.com/package/crev) - baby steps
 * [pip-crev: Crev for Python/PIP](https://github.com/crev-dev/pip-crev) - still early
-* Crev for Julia/Pkg - in plans; ask around on [Crev Matrix channel](https://matrix.to/#/!uBhYhtcoNlyEbzfYAW:matrix.org)
-* other languages/ecosystems - join [Crev Matrix channel](https://matrix.to/#/!uBhYhtcoNlyEbzfYAW:matrix.org), tell us about your interest and find help
+* Crev for Julia/Pkg - in plans; ask around on [Crev Matrix channel](https://matrix.to/#/#crev:matrix.org)
+* other languages/ecosystems - join [Crev Matrix channel](https://matrix.to/#/#crev:matrix.org), tell us about your interest and find help
 
 ## Introduction
 


### PR DESCRIPTION
Joining a room via just a room ID is not supported in the spec, joinning via an alias is the right way to do this. Since the room has an alias set, use that in the matrix.to links